### PR TITLE
clean up and improve cross-schema union methods

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -17,3 +17,4 @@ vars:
     opportunity: "{{ source('pardot','opportunity') }}"
     opportunity_prospect: "{{ source('pardot','opportunity_prospect') }}"
     prospect_passthrough_columns: []
+  source_schema: "split_part(_dbt_source_relation, '.', 1) || '.' || split_part(_dbt_source_relation, '.', 2)"

--- a/macros/generate_pardot_identifiers.sql
+++ b/macros/generate_pardot_identifiers.sql
@@ -2,12 +2,14 @@
 --returns the _dbt_source_relation and pardot business unit abbreviation extracted from source schema
 --renames the original primary key as [model]_schema_specific_id 
 {% macro generate_pardot_identifiers(pre_union_primary_key, model_name=none) %}
+    
     {% set model = model_name if model_name else this.name.split('__')[-1] %}
     
     {{ generate_pardot_surrogate_key(pre_union_primary_key) }} as {{ model }}_id,
-    _dbt_source_relation,
     
-    {{ pre_union_primary_key }} as {{ model }}_schema_specific_id,
+
+    _dbt_source_relation,
+    {{ var('source_schema') }} as {{ model }}_source_schema,
     regexp_replace(
         regexp_replace(
             regexp_substr(_dbt_source_relation, 'PARDOT_(_?\\w+)', 1, 1, 'i', 1),
@@ -17,4 +19,8 @@
         '_',
         ' '
     ) as pardot_business_unit_abbreviation,
+
+    {{ pre_union_primary_key }} as {{ model }}_schema_specific_id,
+    
+
 {% endmacro %}

--- a/macros/generate_pardot_identifiers.sql
+++ b/macros/generate_pardot_identifiers.sql
@@ -7,8 +7,6 @@
     
     {{ generate_pardot_surrogate_key(pre_union_primary_key) }} as {{ model }}_id,
     
-
-    _dbt_source_relation,
     {{ var('source_schema') }} as {{ model }}_source_schema,
     regexp_replace(
         regexp_replace(

--- a/macros/generate_pardot_surrogate_key.sql
+++ b/macros/generate_pardot_surrogate_key.sql
@@ -1,8 +1,5 @@
-{% macro generate_pardot_surrogate_key(pre_union_primary_key, model_name=None) %}
-    {% set model = model_name if model_name else this.name.split('__')[-1] %}
+{% macro generate_pardot_surrogate_key(pre_union_primary_key) %}
 
-    {% set source_schema = "split_part(_dbt_source_relation, '.', 1) || '.' || split_part(_dbt_source_relation, '.', 2)" %}
-
-    {{ dbt_utils.generate_surrogate_key([source_schema, pre_union_primary_key]) }}
+    {{ dbt_utils.generate_surrogate_key([ var('source_schema'), pre_union_primary_key]) }}
 
 {% endmacro %}

--- a/models/stg_pardot__visitor_activity.sql
+++ b/models/stg_pardot__visitor_activity.sql
@@ -32,6 +32,7 @@ base_fields_renamed as (
         /* primary key, schema specific id, schema id, extracted business unit */
         {{generate_pardot_identifiers('id')}}
         
+        _dbt_source_relation,
         type as visitor_activity_type_id,
         type_name as event_type_name,
         prospect_id,
@@ -72,7 +73,6 @@ final as (
         _fivetran_synced,
         
         /* post-union identifiers */
-        _dbt_source_relation,
         visitor_activity_schema_specific_id,
         
         /* foreign keys */


### PR DESCRIPTION
### What it does
- references er-analytics-dbt to derive sufficiently unique list email natural key from market abbreviation, fy, and internal email code (jan01a)
- tweaks identifiers/surrogate key macro to be sufficiently unique / referential