### PR TITLE
`pardot_source` models - databricks migraton

### DIFF
--- a/macros/generate_pardot_identifiers.sql
+++ b/macros/generate_pardot_identifiers.sql
@@ -10,7 +10,7 @@
     {{ var('source_schema') }} as {{ model }}_source_schema,
     regexp_replace(
         regexp_replace(
-            regexp_substr(_dbt_source_relation, 'PARDOT_(_?\\w+)', 1, 1, 'i', 1),
+            regexp_extract(_dbt_source_relation, 'PARDOT_(_?\\w+)', 1),
             '^_',
             ''
         ),

--- a/macros/generate_pardot_identifiers.sql
+++ b/macros/generate_pardot_identifiers.sql
@@ -8,15 +8,15 @@
     {{ generate_pardot_surrogate_key(pre_union_primary_key) }} as {{ model }}_id,
     
     {{ var('source_schema') }} as {{ model }}_source_schema,
-    regexp_replace(
+    upper(regexp_replace(
         regexp_replace(
-            regexp_extract(_dbt_source_relation, 'PARDOT_(_?\\w+)', 1),
+            regexp_extract(_dbt_source_relation, 'pardot__([^.`]+)', 1),
             '^_',
             ''
         ),
         '_',
         ' '
-    ) as pardot_business_unit_abbreviation,
+    )) as pardot_business_unit_abbreviation,
 
     {{ pre_union_primary_key }} as {{ model }}_schema_specific_id
     

--- a/models/src_misc.yml
+++ b/models/src_misc.yml
@@ -3,7 +3,7 @@ version: 2
 sources:
   - name: box__misc_mm
     description: 'Production Raw data from Mass Market'
-    database: er_raw
+    database: federated_snowflake__er_raw
     schema: box__misc_mm
     loader: fivetran
     description: various MM files that have not yet been deemed to require a specific raw schema

--- a/seeds/seed__pardot__visitor_activity_types.csv
+++ b/seeds/seed__pardot__visitor_activity_types.csv
@@ -1,4 +1,4 @@
-visitor_activity_type_id, visitor_activity_type
+visitor_activity_type_id,visitor_activity_type
 1,Click
 2,View
 3,Error


### PR DESCRIPTION
## Pardot Source Migration Summary

## What this does and why
Runs / migrates fivetran forked `pardot_source` models on databricks, as part of the er analytics data migration project from snowflake to databricks. 

Related to [issue #1155 ](https://github.com/theirc/er-analytics-dbt/issues/1155)in the er-analytics-dbt project

## PR type

- [x] Snowflake to Databricks migration


### Results Overview

Total Models: 21
Passed: 10 ✅
Failed: 11 ❌


### Models That Passed ✅

- [x] stg_pardot__campaign_tmp
- [x] stg_pardot__email_template_tmp
- [x] stg_pardot__list_email_tmp
- [x] stg_pardot__list_membership_tmp
- [x] stg_pardot__list_tmp
- [x] stg_pardot__opportunity_prospect_tmp
- [x] stg_pardot__opportunity_tmp
- [x] stg_pardot__prospect_tmp
- [x] stg_pardot__visitor_activity_tmp
- [x] stg_pardot__visitor_tmp


### Models That Failed ❌
1. stg_pardot__campaign
- [x] Column _fivetran_deleted doesn't exist in Databricks tables

2. stg_pardot__email_template
- [x] Column _fivetran_deleted doesn't exist in Databricks tables

3. stg_pardot__prospect
- [x] Column _fivetran_deleted doesn't exist in Databricks tables

4. stg_pardot__list_membership
- [x] regexp_substr has 6 parameters; Databricks only accepts 2-3
- [x] Need to replace with regexp_extract

5. stg_pardot__list
- [x] regexp_substr has 6 parameters; Databricks only accepts 2-3
- [x] Need to replace with regexp_extract

6. stg_pardot__opportunity_prospect
- [x] regexp_substr has 6 parameters; Databricks only accepts 2-3
- [x] Need to replace with regexp_extract

7. stg_pardot__opportunity
- [x] regexp_substr has 6 parameters; Databricks only accepts 2-3
- [x] Need to replace with regexp_extract

8. stg_pardot__visitor
- [x] regexp_substr has 6 parameters; Databricks only accepts 2-3
- [x] Need to replace with regexp_extract

9. stg_pardot__visitor_activity
- [x] regexp_substr has 6 parameters; Databricks only accepts 2-3
- [x] Need to replace with regexp_extract

10. stg_pardot__list_email
- [x] Cannot resolve base.* - the base CTE is empty due to missing source tables


11. stg_box__misc_mm__list_email__manual_records
- [x] Source table pardot_mmus_list_emails_manual_records doesn't exist in Databricks


Migration Action Plan

- [x] Priority 1: Fix regexp_substr → regexp_extract (6 models)
- [x] Priority 2: Remove/handle _fivetran_deleted references (3 models)
- [x] Priority 3: Fix empty table handling (1 model)
- [x] Priority 4: Migrate or disable Box source table (1 model)
- [x] Data validation

###Data Validation results
<img width="1303" height="668" alt="image" src="https://github.com/user-attachments/assets/268243c6-6708-4a91-a00f-9b5cc3d0705d" />

