### PR TITLE
Pardot Email URL builder enhancements - `pardot_source` pipeline

### DIFF
--- a/models/stg_pardot__list_email.sql
+++ b/models/stg_pardot__list_email.sql
@@ -273,15 +273,15 @@ global_list_emails_standard as ( -- An email specific URL builder was rolled out
             and character_length(list_email_name_part_2) in (8,9)
             then left(list_email_name_part_2,3)
         else null
-        end as email_url_builder_month_abbreviated,
+        end as list_email_url_builder_month_abbreviated,
 
         /* Utilising the jinja dictionary that Tyler created in the previous CTE, to now map month abbreviations to full month name */
         case
             {% for month_full, month_abbreviated in month_abbreviations.items() %}
-            when email_url_builder_month_abbreviated ilike '{{ month_abbreviated }}' then initcap('{{ month_full }}')
+            when list_email_url_builder_month_abbreviated ilike '{{ month_abbreviated }}' then initcap('{{ month_full }}')
             {% endfor %}
         else null
-        end as email_url_builder_month_full_name,
+        end as list_email_url_builder_month_full_name,
 
         /* Parsing email version number */
         case 
@@ -289,7 +289,7 @@ global_list_emails_standard as ( -- An email specific URL builder was rolled out
             and character_length(list_email_name_part_2) in (8,9)
             then substring(list_email_name_part_2, 4, 2) -- Extract positions 4-5 which are always two numbers for version number as per URL builder form
             else null
-        end as email_url_builder_version_number,
+        end as list_email_url_builder_version_number,
 
         /* Parsing audience segment code */
 
@@ -298,7 +298,7 @@ global_list_emails_standard as ( -- An email specific URL builder was rolled out
             and character_length(list_email_name_part_2) in (8,9)
             then substring(list_email_name_part_2, 6,3) -- Extract positions 6-8 which are always three characters for audience segment code as per URL builder form
         else null
-        end as email_url_builder_audience_segment_code,
+        end as list_email_url_builder_audience_segment_code,
         
         /* Parsing additional testing variants (non mandatory field in Email URL Builder) */
 
@@ -307,16 +307,16 @@ global_list_emails_standard as ( -- An email specific URL builder was rolled out
                 and character_length(list_email_name_part_2) = 9
             then right(list_email_name_part_2, 1) -- Extract position 9 which is the testing variant when present as per URL builder form
             else null
-        end as email_url_builder_test_variant,
+        end as list_email_url_builder_test_variant,
 
         /* Flag to check that emails are using latest URL builder format from late FY25/early FY26 */
         case 
             when list_email_name_part_1 ilike 'FY%' 
             and character_length(list_email_name_part_2) in (8,9)
-            and email_url_builder_audience_segment_code is not null
+            and list_email_url_builder_audience_segment_code is not null
             then true
             else false 
-        end as is_email_url_builder_format
+        end as is_list_email_url_builder_format
 
         from mmus_enhanced_pre_fy25
 )
@@ -327,4 +327,4 @@ global_list_emails_standard.*,
 seed__pardot__list_email_audience_segments.audience_segment_name as email_url_builder_audience_segment_name
 from global_list_emails_standard
 left join seed__pardot__list_email_audience_segments
-on global_list_emails_standard.email_url_builder_audience_segment_code = seed__pardot__list_email_audience_segments.audience_segment_code
+on global_list_emails_standard.list_email_url_builder_audience_segment_code = seed__pardot__list_email_audience_segments.audience_segment_code

--- a/models/stg_pardot__list_email.sql
+++ b/models/stg_pardot__list_email.sql
@@ -342,7 +342,7 @@ global_list_emails_standard as ( -- An email specific URL builder was rolled out
 
 select 
 global_list_emails_standard.*,
-seed__pardot__list_email_audience_segments.audience_segment_name as email_url_builder_audience_segment_name
+seed__pardot__list_email_audience_segments.audience_segment_name as list_email_url_builder_audience_segment_name
 from global_list_emails_standard
 left join seed__pardot__list_email_audience_segments
 on global_list_emails_standard.list_email_url_builder_audience_segment_code = seed__pardot__list_email_audience_segments.audience_segment_code

--- a/models/stg_pardot__list_email.sql
+++ b/models/stg_pardot__list_email.sql
@@ -320,6 +320,7 @@ global_list_emails_standard as ( -- An email specific URL builder was rolled out
         /* Flag to check that emails are using latest URL builder format from late FY25/early FY26 */
         case 
             when list_email_name_part_1 ilike 'FY%' 
+            and character_length(list_email_name_part_1) = 4 
             and character_length(list_email_name_part_2) in (8,9)
             and list_email_url_builder_audience_segment_code is not null
             then true

--- a/models/stg_pardot__list_email.sql
+++ b/models/stg_pardot__list_email.sql
@@ -167,7 +167,7 @@ mmus_enhanced_pre_fy25 as (
         left(upper(regexp_replace(mmus_pre_fy25_clean_month_names, '[# ]', '')),6) as mmus_pre_fy25_list_email_name_internal_id,
 
 
-        list_email_name_part_1 as list_email_name_year,
+        list_email_name_part_1 as mmus_pre_fy25_list_email_name_year,
         mass_market_abbreviation||list_email_sent_fiscal_year||mmus_pre_fy25_list_email_name_internal_id as mmus_pre_fy25_list_email_natural_key,
 
         /* derive list email type from split part 3 */
@@ -255,7 +255,7 @@ mmus_enhanced_pre_fy25 as (
 
 ),
 
-mm_cross_market_url_builder_list_emails_tracking as ( -- An email specific URL builder was rolled out globally in late FY25, with full adoption across markets from FY26. See https://theirc.github.io/URLBuilder/#emailUrlGenPage
+mm_cross_market_list_emails_tracking as ( -- An email specific URL builder was rolled out globally in late FY25, with full adoption across markets from FY26. See https://theirc.github.io/URLBuilder/#emailUrlGenPage
     
     select
         *,
@@ -265,7 +265,7 @@ mm_cross_market_url_builder_list_emails_tracking as ( -- An email specific URL b
             and character_length(list_email_name_part_1) = 4
             then upper(list_email_name_part_1)
             else null
-        end as list_email_url_builder_fiscal_year,
+        end as list_email_fiscal_year,
 
         /* Parsing part 2 of the list email name into component parts to enable filters/group bys on Power BI reports
         
@@ -278,7 +278,7 @@ mm_cross_market_url_builder_list_emails_tracking as ( -- An email specific URL b
             and character_length(list_email_name_part_2) in (8,9)
             then left(list_email_name_part_2,3)
         else null
-        end as list_email_url_builder_month_abbreviated,
+        end as list_email_month_abbreviated,
 
         /* Parsing email version number */
         case 
@@ -286,7 +286,7 @@ mm_cross_market_url_builder_list_emails_tracking as ( -- An email specific URL b
             and character_length(list_email_name_part_2) in (8,9)
             then substring(list_email_name_part_2, 4, 2) -- Extract positions 4-5 which are always two numbers for version number as per URL builder form
             else null
-        end as list_email_url_builder_version_number,
+        end as list_email_version_number,
 
         /* Parsing audience segment code */
 
@@ -295,7 +295,7 @@ mm_cross_market_url_builder_list_emails_tracking as ( -- An email specific URL b
             and character_length(list_email_name_part_2) in (8,9)
             then substring(list_email_name_part_2, 6,3) -- Extract positions 6-8 which are always three characters for audience segment code as per URL builder form
         else null
-        end as list_email_url_builder_audience_segment_code,
+        end as list_email_audience_segment_code,
         
         /* Parsing additional testing variants (non mandatory field in Email URL Builder) */
 
@@ -304,14 +304,14 @@ mm_cross_market_url_builder_list_emails_tracking as ( -- An email specific URL b
                 and character_length(list_email_name_part_2) = 9
             then right(list_email_name_part_2, 1) -- Extract position 9 which is the testing variant when present as per URL builder form
             else null
-        end as list_email_url_builder_test_variant,
+        end as list_email_test_variant,
 
         /* Flag to check that emails are using latest URL builder format from late FY25/early FY26 */
         case 
             when list_email_name_part_1 ilike 'FY%' 
             and character_length(list_email_name_part_1) = 4 
             and character_length(list_email_name_part_2) in (8,9)
-            and list_email_url_builder_audience_segment_code is not null
+            and list_email_audience_segment_code is not null
             then true
             else false 
         end as is_list_email_url_builder_format,
@@ -322,17 +322,17 @@ mm_cross_market_url_builder_list_emails_tracking as ( -- An email specific URL b
             and character_length(list_email_name_part_2) in (8,9)
             then list_email_name_part_3
             else null
-        end as list_email_url_builder_email_type,
+        end as list_email_type,
 
 
         /* Natural key components to join to donations */
         case when is_list_email_url_builder_format then
-            upper(list_email_url_builder_month_abbreviated)||upper(list_email_url_builder_version_number)||upper(list_email_url_builder_audience_segment_code)||coalesce(list_email_url_builder_test_variant,'')
+            upper(list_email_month_abbreviated)||upper(list_email_version_number)||upper(list_email_audience_segment_code)||coalesce(list_email_test_variant,'')
         else null
         end as list_email_name_internal_id,
 
         case when is_list_email_url_builder_format then
-            mass_market_abbreviation||list_email_url_builder_fiscal_year||list_email_name_internal_id
+            mass_market_abbreviation||list_email_fiscal_year||list_email_name_internal_id
         else null
         end as list_email_natural_key
 
@@ -341,8 +341,8 @@ mm_cross_market_url_builder_list_emails_tracking as ( -- An email specific URL b
 
 
 select 
-mm_cross_market_url_builder_list_emails_tracking.*,
-seed__pardot__list_email_audience_segments.audience_segment_name as list_email_url_builder_audience_segment_name
-from mm_cross_market_url_builder_list_emails_tracking
+mm_cross_market_list_emails_tracking.*,
+seed__pardot__list_email_audience_segments.audience_segment_name as list_email_audience_segment_name
+from mm_cross_market_list_emails_tracking
 left join seed__pardot__list_email_audience_segments
-on mm_cross_market_url_builder_list_emails_tracking.list_email_url_builder_audience_segment_code = seed__pardot__list_email_audience_segments.audience_segment_code
+on mm_cross_market_list_emails_tracking.list_email_audience_segment_code = seed__pardot__list_email_audience_segments.audience_segment_code

--- a/models/stg_pardot__list_email.sql
+++ b/models/stg_pardot__list_email.sql
@@ -76,31 +76,16 @@ seed__pardot__list_email_audience_segments as (
 list_emails_joined as (
 
     select 
-        *
-    
-    from fields
-    
-    left join seed_pardot_business_unit using (pardot_business_unit_abbreviation)
+        fields.*,
+        seed_pardot_business_unit.mass_market_abbreviation,
+        seed_pardot_business_unit.pardot_business_unit_abbreviation,
 
-),
-
-
-mmus_enhanced_pre_fy25 as (
-    
-    select 
-        /* primary key, schema specific id, schema id, extracted business unit */
-        list_email_id,
-        list_email_source_schema,
-        pardot_business_unit_abbreviation,
-        mass_market_abbreviation,
-        list_email_schema_specific_id,
-        
-        /* basics */
+        /* basics - used by both legacy mmus tracking and new cross-market tracking */
         sent_at as list_email_sent_at,
         {{fiscal_year('list_email_sent_at','list_email_sent')}},
         name as list_email_name,
 
-        /* split list email name to parts */
+        /* split list email name to parts - also used by both tracking formats*/
         {% set list_email_name_parts = range(1, 9) %}
         
         {% for list_email_name_part in list_email_name_parts %}
@@ -117,13 +102,39 @@ mmus_enhanced_pre_fy25 as (
             ) as list_email_name_part_{{ list_email_name_part }},
         {% endfor %}
         
-        /* validate whether the email name has mmus formatting, defined: first split part of the name is a year on or after 2022 */    
+        case when list_email_name ilike any ('%test%') then true else false end as is_test,
+
+        /* List email attributes - used by both */
+        subject as list_email_subject,
+        text_message as list_email_message_text,
+        client_type as list_email_client_type,
+        
+        is_deleted as is_deleted_list_email,
+        is_paused as is_paused_list_email,
+        is_sent as is_sent_list_email,
+
+        /* Timestamps - used by both */
+        created_at as created_timestamp,
+        updated_at as updated_timestamp,
+        _fivetran_synced
+    
+    from fields
+    
+    left join seed_pardot_business_unit using (pardot_business_unit_abbreviation)
+
+),
+
+/* legacy MMUS-only logic, prior to introduction of global email URL builder. Keeping in this CTE for historical reference */
+
+mmus_enhanced_pre_fy25 as (
+    
+    select 
+    *,
         case
             when try_cast(list_email_name_part_1 as integer) >= 2022
             then true
             else false
         end as is_mmus_formated_list_email_name,
-        case when list_email_name ilike any ('%test%') then true else false end as is_test,
 
         /* natural key */
         /* cleans list email name month names and special characters to produce uniform coding in the style jan01a */
@@ -152,15 +163,15 @@ mmus_enhanced_pre_fy25 as (
                     '{{ month_abbreviated }}')
             {% endfor %}
             else list_email_name_part_2
-        end as clean_month_names,
-        left(upper(regexp_replace(clean_month_names, '[# ]', '')),6) as mmus_pre_fy25_list_email_name_internal_id,
+        end as mmus_pre_fy25_clean_month_names,
+        left(upper(regexp_replace(mmus_pre_fy25_clean_month_names, '[# ]', '')),6) as mmus_pre_fy25_list_email_name_internal_id,
 
 
         list_email_name_part_1 as list_email_name_year,
         mass_market_abbreviation||list_email_sent_fiscal_year||mmus_pre_fy25_list_email_name_internal_id as mmus_pre_fy25_list_email_natural_key,
 
         /* derive list email type from split part 3 */
-        list_email_name_part_4 as list_email_name_parsed_topic,
+        list_email_name_part_4 as mmus_pre_fy25_list_email_name_parsed_topic,
 
         /* list email segment - special logic to extract conformed attribute from name */
         {% set segment_keywords = {
@@ -195,14 +206,14 @@ mmus_enhanced_pre_fy25 as (
             when list_email_name ilike '{{ segment_keyword }}' then '{{ segment_conformed }}'
         {% endfor %}
             else null
-        end as list_email_keyword_segment,
+        end as mmus_pre_fy25_list_email_keyword_segment,
 
         case
         {% for status_keyword, status_conformed in status_keywords.items() %}
             when list_email_name ilike '{{ status_keyword }}' then '{{ status_conformed }}'
         {% endfor %}
             else null
-        end as list_email_keyword_status,
+        end as mmus_pre_fy25_list_email_keyword_status,
 
         case
         {% for type_keyword, type_conformed in type_keywords.items() %}
@@ -224,7 +235,7 @@ mmus_enhanced_pre_fy25 as (
             then list_email_name_part_{{ list_email_name_part_number }}
             {%- endfor %}
             else null
-        end as segment_keyword_found_string,
+        end as mmus_pre_fy25_segment_keyword_found_string,
         
         /* in which parsed name part the keyword is found */
        case
@@ -238,27 +249,13 @@ mmus_enhanced_pre_fy25 as (
             then 'list_email_name_part_{{ list_email_name_part_number }}'
             {% endfor %}
             else null
-        end as segment_keyword_found_in_list_email_name_part,
-
-        /* list email attributes */
-        subject as list_email_subject,
-        text_message as list_email_message_text,
-        client_type as list_email_client_type,
-        
-        is_deleted as is_deleted_list_email,
-        is_paused as is_paused_list_email,
-        is_sent as is_sent_list_email,
-
-        /* timestamps */
-        created_at as created_timestamp,
-        updated_at as updated_timestamp,
-        _fivetran_synced
+        end as mmus_pre_fy25_segment_keyword_found_in_list_email_name_part
     
     from list_emails_joined
 
 ),
 
-global_list_emails_standard as ( -- An email specific URL builder was rolled out globally in late FY25, with full adoption across markets from FY26. See https://theirc.github.io/URLBuilder/#emailUrlGenPage
+mm_cross_market_url_builder_list_emails_tracking as ( -- An email specific URL builder was rolled out globally in late FY25, with full adoption across markets from FY26. See https://theirc.github.io/URLBuilder/#emailUrlGenPage
     
     select
         *,
@@ -282,14 +279,6 @@ global_list_emails_standard as ( -- An email specific URL builder was rolled out
             then left(list_email_name_part_2,3)
         else null
         end as list_email_url_builder_month_abbreviated,
-
-        /* Utilising the jinja dictionary that Tyler created in the previous CTE, to now map month abbreviations to full month name */
-        case
-            {% for month_full, month_abbreviated in month_abbreviations.items() %}
-            when list_email_url_builder_month_abbreviated ilike '{{ month_abbreviated }}' then initcap('{{ month_full }}')
-            {% endfor %}
-        else null
-        end as list_email_url_builder_month_full_name,
 
         /* Parsing email version number */
         case 
@@ -342,8 +331,8 @@ global_list_emails_standard as ( -- An email specific URL builder was rolled out
 
 
 select 
-global_list_emails_standard.*,
+mm_cross_market_url_builder_list_emails_tracking.*,
 seed__pardot__list_email_audience_segments.audience_segment_name as list_email_url_builder_audience_segment_name
-from global_list_emails_standard
+from mm_cross_market_url_builder_list_emails_tracking
 left join seed__pardot__list_email_audience_segments
-on global_list_emails_standard.list_email_url_builder_audience_segment_code = seed__pardot__list_email_audience_segments.audience_segment_code
+on mm_cross_market_url_builder_list_emails_tracking.list_email_url_builder_audience_segment_code = seed__pardot__list_email_audience_segments.audience_segment_code

--- a/models/stg_pardot__list_email.sql
+++ b/models/stg_pardot__list_email.sql
@@ -153,12 +153,11 @@ mmus_enhanced_pre_fy25 as (
             {% endfor %}
             else list_email_name_part_2
         end as clean_month_names,
-        left(upper(regexp_replace(clean_month_names, '[# ]', '')),6) as list_email_name_internal_id,
+        left(upper(regexp_replace(clean_month_names, '[# ]', '')),6) as mmus_pre_fy25_list_email_name_internal_id,
 
 
         list_email_name_part_1 as list_email_name_year,
-        mass_market_abbreviation||list_email_sent_fiscal_year||list_email_name_internal_id as list_email_natural_key,
-
+        mass_market_abbreviation||list_email_sent_fiscal_year||mmus_pre_fy25_list_email_name_internal_id as mmus_pre_fy25_list_email_natural_key,
 
         /* derive list email type from split part 3 */
         list_email_name_part_4 as list_email_name_parsed_topic,
@@ -263,11 +262,20 @@ global_list_emails_standard as ( -- An email specific URL builder was rolled out
     
     select
         *,
+
+        case 
+            when list_email_name_part_1 ilike 'FY%'
+            and character_length(list_email_name_part_1) = 4
+            then upper(list_email_name_part_1)
+            else null
+        end as list_email_url_builder_fiscal_year,
+
         /* Parsing part 2 of the list email name into component parts to enable filters/group bys on Power BI reports
         
         Example Dec01MLM needs to be broken up further to show month_abbreviation (Dec), email version number (01) and email segment code (MLM) */
 
         /* Parsing email month_abbreviated */
+
         case 
             when list_email_name_part_1 ilike 'FY%'
             and character_length(list_email_name_part_2) in (8,9)
@@ -316,7 +324,17 @@ global_list_emails_standard as ( -- An email specific URL builder was rolled out
             and list_email_url_builder_audience_segment_code is not null
             then true
             else false 
-        end as is_list_email_url_builder_format
+        end as is_list_email_url_builder_format,
+
+        case when is_list_email_url_builder_format then
+            list_email_url_builder_month_abbreviated||list_email_url_builder_version_number||list_email_url_builder_audience_segment_code||coalesce(list_email_url_builder_test_variant,'')
+        else null
+        end as list_email_name_internal_id,
+
+        case when is_list_email_url_builder_format then
+            mass_market_abbreviation||list_email_url_builder_fiscal_year||list_email_name_internal_id
+        else null
+        end as list_email_natural_key
 
         from mmus_enhanced_pre_fy25
 )

--- a/models/stg_pardot__list_email.sql
+++ b/models/stg_pardot__list_email.sql
@@ -68,13 +68,10 @@ seed_pardot_business_unit as (
 ),
 
 seed__pardot__list_email_audience_segments as (
-
-    select 
-        * 
-    
+    select * 
     from {{ ref('seed__pardot__list_email_audience_segments')}}
-
 ),
+
 
 list_emails_joined as (
 
@@ -273,55 +270,61 @@ global_list_emails_standard as ( -- An email specific URL builder was rolled out
         /* Parsing email month_abbreviated */
         case 
             when list_email_name_part_1 ilike 'FY%'
-            and character_length(list_email_name_part_2) = 8
+            and character_length(list_email_name_part_2) in (8,9)
             then left(list_email_name_part_2,3)
         else null
-        end as email_month_abbreviated,
+        end as email_url_builder_month_abbreviated,
 
         /* Utilising the jinja dictionary that Tyler created in the previous CTE, to now map month abbreviations to full month name */
         case
             {% for month_full, month_abbreviated in month_abbreviations.items() %}
-            when email_month_abbreviated ilike '{{ month_abbreviated }}' then initcap('{{ month_full }}')
+            when email_url_builder_month_abbreviated ilike '{{ month_abbreviated }}' then initcap('{{ month_full }}')
             {% endfor %}
         else null
-        end as email_month_full_name,
+        end as email_url_builder_month_full_name,
 
         /* Parsing email version number */
         case 
             when list_email_name_part_1 ilike 'FY%'
-            and character_length(list_email_name_part_2) = 8
+            and character_length(list_email_name_part_2) in (8,9)
             then substring(list_email_name_part_2, 4, 2) -- Extract positions 4-5 which are always two numbers for version number as per URL builder form
             else null
-        end as email_version_number,
+        end as email_url_builder_version_number,
 
         /* Parsing audience segment code */
 
         case 
             when list_email_name_part_1 ilike 'FY%'
-            and character_length(list_email_name_part_2) = 8
-            then right(list_email_name_part_2, 3)
+            and character_length(list_email_name_part_2) in (8,9)
+            then substring(list_email_name_part_2, 6,3) -- Extract positions 6-8 which are always three characters for audience segment code as per URL builder form
         else null
-        end as audience_segment_code,
+        end as email_url_builder_audience_segment_code,
+        
+        /* Parsing additional testing variants (non mandatory field in Email URL Builder) */
 
-        seed__pardot__list_email_audience_segments.audience_segment_name as audience_segment_name,
+        case 
+            when list_email_name_part_1 ilike 'FY%'
+                and character_length(list_email_name_part_2) = 9
+            then right(list_email_name_part_2, 1) -- Extract position 9 which is the testing variant when present as per URL builder form
+            else null
+        end as email_url_builder_test_variant,
 
         /* Flag to check that emails are using latest URL builder format from late FY25/early FY26 */
         case 
             when list_email_name_part_1 ilike 'FY%' 
-            and character_length(list_email_name_part_2) = 8
-            and audience_segment_code is not null
+            and character_length(list_email_name_part_2) in (8,9)
+            and email_url_builder_audience_segment_code is not null
             then true
             else false 
-        end as is_global_standard_url_builder_format
+        end as is_email_url_builder_format
 
         from mmus_enhanced_pre_fy25
-        left join seed__pardot__list_email_audience_segments
-        on right(list_email_name_part_2, 3) = seed__pardot__list_email_audience_segments.audience_segment_code
-        and list_email_name_part_1 ilike 'FY%'
-        and character_length(list_email_name_part_2) = 8
-
-
-
 )
 
-select * from global_list_emails_standard
+
+select 
+global_list_emails_standard.*,
+seed__pardot__list_email_audience_segments.audience_segment_name
+from global_list_emails_standard
+left join seed__pardot__list_email_audience_segments
+on global_list_emails_standard.email_url_builder_audience_segment_code = seed__pardot__list_email_audience_segments.audience_segment_code

--- a/models/stg_pardot__list_email.sql
+++ b/models/stg_pardot__list_email.sql
@@ -324,7 +324,7 @@ global_list_emails_standard as ( -- An email specific URL builder was rolled out
 
 select 
 global_list_emails_standard.*,
-seed__pardot__list_email_audience_segments.audience_segment_name
+seed__pardot__list_email_audience_segments.audience_segment_name as email_url_builder_audience_segment_name
 from global_list_emails_standard
 left join seed__pardot__list_email_audience_segments
 on global_list_emails_standard.email_url_builder_audience_segment_code = seed__pardot__list_email_audience_segments.audience_segment_code

--- a/models/stg_pardot__list_email.sql
+++ b/models/stg_pardot__list_email.sql
@@ -327,7 +327,7 @@ mm_cross_market_url_builder_list_emails_tracking as ( -- An email specific URL b
 
         /* Natural key components to join to donations */
         case when is_list_email_url_builder_format then
-            list_email_url_builder_month_abbreviated||list_email_url_builder_version_number||list_email_url_builder_audience_segment_code||coalesce(list_email_url_builder_test_variant,'')
+            upper(list_email_url_builder_month_abbreviated)||upper(list_email_url_builder_version_number)||upper(list_email_url_builder_audience_segment_code)||coalesce(list_email_url_builder_test_variant,'')
         else null
         end as list_email_name_internal_id,
 

--- a/models/stg_pardot__list_email.sql
+++ b/models/stg_pardot__list_email.sql
@@ -67,6 +67,15 @@ seed_pardot_business_unit as (
 
 ),
 
+seed__pardot__list_email_audience_segments as (
+
+    select 
+        * 
+    
+    from {{ ref('seed__pardot__list_email_audience_segments')}}
+
+),
+
 list_emails_joined as (
 
     select 
@@ -79,7 +88,7 @@ list_emails_joined as (
 ),
 
 
-list_emails_enhanced as (
+mmus_enhanced_pre_fy25 as (
     
     select 
         /* primary key, schema specific id, schema id, extracted business unit */
@@ -251,6 +260,68 @@ list_emails_enhanced as (
     
     from list_emails_joined
 
+),
+
+global_list_emails_standard as ( -- An email specific URL builder was rolled out globally in late FY25, with full adoption across markets from FY26. See https://theirc.github.io/URLBuilder/#emailUrlGenPage
+    
+    select
+        *,
+        /* Parsing part 2 of the list email name into component parts to enable filters/group bys on Power BI reports
+        
+        Example Dec01MLM needs to be broken up further to show month_abbreviation (Dec), email version number (01) and email segment code (MLM) */
+
+        /* Parsing email month_abbreviated */
+        case 
+            when list_email_name_part_1 ilike 'FY%'
+            and character_length(list_email_name_part_2) = 8
+            then left(list_email_name_part_2,3)
+        else null
+        end as email_month_abbreviated,
+
+        /* Utilising the jinja dictionary that Tyler created in the previous CTE, to now map month abbreviations to full month name */
+        case
+            {% for month_full, month_abbreviated in month_abbreviations.items() %}
+            when email_month_abbreviated ilike '{{ month_abbreviated }}' then initcap('{{ month_full }}')
+            {% endfor %}
+        else null
+        end as email_month_full_name,
+
+        /* Parsing email version number */
+        case 
+            when list_email_name_part_1 ilike 'FY%'
+            and character_length(list_email_name_part_2) = 8
+            then substring(list_email_name_part_2, 4, 2) -- Extract positions 4-5 which are always two numbers for version number as per URL builder form
+            else null
+        end as email_version_number,
+
+        /* Parsing audience segment code */
+
+        case 
+            when list_email_name_part_1 ilike 'FY%'
+            and character_length(list_email_name_part_2) = 8
+            then right(list_email_name_part_2, 3)
+        else null
+        end as audience_segment_code,
+
+        seed__pardot__list_email_audience_segments.audience_segment_name as audience_segment_name,
+
+        /* Flag to check that emails are using latest URL builder format from late FY25/early FY26 */
+        case 
+            when list_email_name_part_1 ilike 'FY%' 
+            and character_length(list_email_name_part_2) = 8
+            and audience_segment_code is not null
+            then true
+            else false 
+        end as is_global_standard_url_builder_format
+
+        from mmus_enhanced_pre_fy25
+        left join seed__pardot__list_email_audience_segments
+        on right(list_email_name_part_2, 3) = seed__pardot__list_email_audience_segments.audience_segment_code
+        and list_email_name_part_1 ilike 'FY%'
+        and character_length(list_email_name_part_2) = 8
+
+
+
 )
 
-select * from list_emails_enhanced
+select * from global_list_emails_standard

--- a/models/stg_pardot__list_email.sql
+++ b/models/stg_pardot__list_email.sql
@@ -220,7 +220,7 @@ mmus_enhanced_pre_fy25 as (
             when list_email_name ilike '{{ type_keyword }}' then '{{ type_conformed }}'
         {% endfor %}
             else null
-        end as list_email_keyword_type,
+        end as mmus_pre_fy25_list_email_keyword_type,
 
         /* in which parsed string the keyword is found */
         {% set list_email_name_segment_part_numbers = range(4, 9) %}
@@ -316,6 +316,16 @@ mm_cross_market_url_builder_list_emails_tracking as ( -- An email specific URL b
             else false 
         end as is_list_email_url_builder_format,
 
+        case 
+            when list_email_name_part_1 ilike 'FY%'
+            and character_length(list_email_name_part_1) = 4
+            and character_length(list_email_name_part_2) in (8,9)
+            then list_email_name_part_3
+            else null
+        end as list_email_url_builder_email_type,
+
+
+        /* Natural key components to join to donations */
         case when is_list_email_url_builder_format then
             list_email_url_builder_month_abbreviated||list_email_url_builder_version_number||list_email_url_builder_audience_segment_code||coalesce(list_email_url_builder_test_variant,'')
         else null

--- a/seeds/seed__pardot__list_email_audience_segments.csv
+++ b/seeds/seed__pardot__list_email_audience_segments.csv
@@ -1,0 +1,51 @@
+audience_segment_code,audience_segment_name
+STM,Standard Mailable
+STN,Standard Nonmailable
+STE,Standard Emergency
+STU,Standard Ukraine
+STA,Standard Active
+STL,Standard Lapsed
+STX,Standard Mix
+STT,Standard Total
+PRO,Prospect
+PGD,Planned Giving Donors
+PGP,Planned Giving Prospects
+MLM,Mid-Level Mailable
+MLN,Mid-Level Nonmailable
+MLE,Mid-Level Emergency
+MLU,Mid-Level Ukraine
+MLA,Mid-Level Active
+MLL,Mid-Level Lapsed
+MLP,Mid-Level Prospect
+MLX,Mid-Level Mix
+MLT,Mid-Level Total
+RSM,Sustainer Mailable
+RSN,Sustainer Nonmailable
+RSE,Sustainer Emergency
+RSU,Sustainer Ukraine
+RSA,Sustainer Active
+RS1,Sustainer Lapsing 1
+RS2,Sustainer Lapsing 2
+RSL,Sustainer Lapsed Total
+RGR,Sustainer Reactivation
+RSX,Sustainer Mix
+RST,Sustainer Total
+AEM,All Engaged Mailable
+AEN,All Engaged Nonmailable
+AET,All Engaged Total
+BRM,Bridge Mailable
+BRN,Bridge Nonmailable
+BRE,Bridge Emergency
+BRU,Bridge Ukraine
+BRA,Bridge Active
+BRL,Bridge Lapsed
+BRX,Bridge Mix
+BRT,Bridge Total
+RIM,RAI Mailable
+RIN,RAI Nonmailable
+RIA,RAI Active
+RIL,RAI Lapsed
+RIX,RAI Mix
+RIT,RAI Total
+ALL,All
+MX,Mixed


### PR DESCRIPTION
As part of [issue number 1291 on the era-dbt repo](https://github.com/theirc/er-analytics-dbt/issues/1291), this PR aims to enrich `pardot_source` models with code for dimensions available within the newly developed email-specific URL builder, created in late FY25


The dimensions are listed below:

 `list_email_month_abbreviated`
 `list_email_month_full_name`
`list_email_version_number`
 `list_email_audience_segment_code`
 `list_email_audience_segment_name`
 `list_email_test_variant`
`is_list_email_url_builder_format` (flag to check that new email URL builder is being utilised for email donation tracking using market source codes)

As well as new dimensions, updates will be made to existing keys generated from the list email name, enabling a join to donations, which use same keys from `market_source` parsing. The keys which will be updated are listed below:

`list_email_internal_name_id`
`list_email_natural_key`


These dimensions and keys will be built / updated on the `stg_pardot__list_email` model  on `pardot_source` dbt package/repo, and then passed through to `pardot` and main `er-analytics-dbt` pipelines and repo's, respectively.

Acceptance criteria 
- [x] Create a seed to show 1:1 relationship for list email segment code and list email segment name (e.g MLM = Mid-Level Mailable)
- [x] Enhance `stg_pardot__list_email` with `global_list_email_standard` CTE to split parts of list email name into dimensional attributes (e.g segment, testing segment, version number, fiscal year). Where possible - reuse  Tyler's email code which was developed for MMUS prior to the new URL builder and standards being rolled out globally
- [x] Update join keys `list_email_name_internal_id` and `list_email_natural_key` with segment code and optional additional testing variant dimensions from the new email URL builder. Keep previous mmus-only versions, however update column names to 'mmus_pre_fy25' for clarity

### Data Model Lineage
<img width="1824" height="215" alt="image" src="https://github.com/user-attachments/assets/de8cc619-6999-4927-b8b4-a11ad159065b" />


### Local run/logs
```
dbt run -s +email_activities
15:04:19  Done. PASS=67 WARN=0 ERROR=0 SKIP=0 TOTAL=67
```

### How was it tested

#### Testing for % of emails in FY26 using new global standards
95% emails following standard as defined in the code

```
select 
count(*) as total_rows,
count(is_list_email_url_builder_format) as emails_with_new_url_builder_format,
count(is_list_email_url_builder_format) / count(*) as percent_with_new_url_builder_format
from irc_martech__raw_dev.dbt_andrew__dev.email_activities 
where activity_metric_outcome = 'Sent'
and timestamp >= DATE '2025-10-01'
```

<img width="777" height="129" alt="image" src="https://github.com/user-attachments/assets/f9f1ad9a-5490-46c1-b07f-5cb143ff74e7" />


#### Testing how well email name is parsing new email_url_builder_* attributes and generating correct natural key

```
select 
list_email_name,
mass_market_abbreviation,
list_email_sent_fiscal_year,
list_email_url_builder_month_abbreviated,
list_email_url_builder_version_number,
list_email_url_builder_audience_segment_code,
list_email_url_builder_audience_segment_name,
list_email_name_internal_id,
list_email_natural_key
from irc_martech__raw_dev.dbt_andrew__dev.stg_pardot__list_email
where is_list_email_url_builder_format
and list_email_sent_at >= DATE '2025-10-01'
```
<img width="1635" height="600" alt="image" src="https://github.com/user-attachments/assets/ffb07357-a9b5-4f23-9a56-d65231cca4fc" />

Quick check on any natural key nulls 
Confirmed no nulls

```
select 
list_email_name,
mass_market_abbreviation,
list_email_sent_fiscal_year,
list_email_url_builder_month_abbreviated,
list_email_url_builder_version_number,
list_email_url_builder_audience_segment_code,
list_email_url_builder_audience_segment_name,
list_email_name_internal_id,
list_email_natural_key
from irc_martech__raw_dev.dbt_andrew__dev.stg_pardot__list_email
where is_list_email_url_builder_format
and list_email_sent_at >= DATE '2025-10-01'
and list_email_natural_key is null
```
<img width="1628" height="186" alt="image" src="https://github.com/user-attachments/assets/66a0cb66-ded7-40d0-bb35-c96d6a2866cd" />

