### PR TITLE
Fixing casing on `list_email_test_variant`

### DIFF
--- a/models/stg_pardot__list_email.sql
+++ b/models/stg_pardot__list_email.sql
@@ -327,7 +327,7 @@ mm_cross_market_list_emails_tracking as ( -- An email specific URL builder was r
 
         /* Natural key components to join to donations */
         case when is_list_email_url_builder_format then
-            upper(list_email_month_abbreviated)||upper(list_email_version_number)||upper(list_email_audience_segment_code)||coalesce(list_email_test_variant,'')
+            upper(list_email_month_abbreviated)||upper(list_email_version_number)||upper(list_email_audience_segment_code)||upper(coalesce(list_email_test_variant,''))
         else null
         end as list_email_name_internal_id,
 

--- a/models/stg_pardot__list_email.sql
+++ b/models/stg_pardot__list_email.sql
@@ -327,7 +327,7 @@ mm_cross_market_list_emails_tracking as ( -- An email specific URL builder was r
 
         /* Natural key components to join to donations */
         case when is_list_email_url_builder_format then
-            upper(list_email_month_abbreviated)||upper(list_email_version_number)||upper(list_email_audience_segment_code)||upper(coalesce(list_email_test_variant,''))
+            upper(list_email_month_abbreviated)||list_email_version_number||list_email_audience_segment_code||coalesce(list_email_test_variant,'')
         else null
         end as list_email_name_internal_id,
 


### PR DESCRIPTION
## What this does and why

- [x] Adds upper casing to `list_email_test_variant` to on stg_pardot_list_email to ensure matching with list_email_natural_key on donations pipeline 

## PR type
- [x] New feature (non-breaking change which adds functionality)

## Related Issues and PRs
- issue [linked here](https://github.com/theirc/er-analytics-dbt/issues/1568) 

## dbt dev/local run logs

```
(dbt-env-dbx) PS C:\Users\AndrewLo\Repos\er-analytics-dbt> dbt build -s +email_activities

10:48:57  Running with dbt=1.9.711:03:40  Done. PASS=216 WARN=34 ERROR=0 SKIP=0 TOTAL=250
```

## How it was tested

```
select
    'dev' as source,
    list_email_natural_key,
    sum(opportunity_sf_usd_rav_amount) as revenue
from irc_martech__raw_dev.dbt_andrew__dev.email_activities
where list_email_natural_key in ('USFY26FEB20AETA', 'USFY26FEB20AETB', 'USFY26FEB19AETA', 'USFY26FEB19AETB')
group by list_email_natural_key

union all

select
    'prod' as source,
    list_email_natural_key,
    sum(opportunity_sf_usd_rav_amount) as revenue
from irc_er.gold_analytics.email_activities
where list_email_natural_key in ('USFY26FEB20AETa', 'USFY26FEB20AETb', 'USFY26FEB19AETa', 'USFY26FEB19AETb')
group by list_email_natural_key

order by list_email_natural_key
```

<img width="433" height="242" alt="image" src="https://github.com/user-attachments/assets/a52f45c1-7a76-4ffb-9f29-0360f99178c6" />

Revenue figures above align with Heidi S comment in Email Reporting Teams Chat:

<img width="906" height="144" alt="image" src="https://github.com/user-attachments/assets/2ae4a410-ca35-4d83-8b8f-ca7c11ab0916" />




## Are there any post-deployment steps?

_thinking we may need to catch up main with main-databricks on this repo too, have routed this to main-databricks for now_

## Additional discussion
(Optional.)